### PR TITLE
NLSteveO/fix search field missing some results

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -27,7 +27,7 @@ function App() {
         <ReactSearchBox
           placeholder="Search for an Emoji..."
           onChange={value => {
-            let regExp = new RegExp(value, "gi");
+            let regExp = new RegExp(value, "i");
             setResults(emojipedia.filter(element => regExp.test(element.name)));
           }}
           fuseConfigs={{


### PR DESCRIPTION
Using the global flag for RegExp will advance the lastIndex property of the regExp when test returns true and resets lastIndex to zero when test returns false.

This works better when searching one large string and you want to find multiple results without getting the same result over and over. In the use case for Emojipedia we want the lastIndex to reset to zero because regExp will be searching a new string as we filter the list and so we want it to check from the beginning of each string.